### PR TITLE
fix: Heap corruption when reducing reducing number of points in Line.

### DIFF
--- a/visage_graphics/line.h
+++ b/visage_graphics/line.h
@@ -44,9 +44,10 @@ namespace visage {
         values = std::make_unique<float[]>(points);
 
         if (num_points) {
-          std::memcpy(x.get(), old_x.get(), num_points * sizeof(float));
-          std::memcpy(y.get(), old_y.get(), num_points * sizeof(float));
-          std::memcpy(values.get(), old_values.get(), num_points * sizeof(float));
+          const int pointsToCopy = std::min(num_points, points);
+          std::memcpy(x.get(), old_x.get(), pointsToCopy * sizeof(float));
+          std::memcpy(y.get(), old_y.get(), pointsToCopy * sizeof(float));
+          std::memcpy(values.get(), old_values.get(), pointsToCopy * sizeof(float));
         }
       }
 


### PR DESCRIPTION
memcpy was always copying num_points elements even if the new size was smaller than num_points.

Any thoughts on just using std::vector in here and resizing?