### PR TITLE
Add a `children()` method to Frame

### DIFF
--- a/visage_ui/frame.h
+++ b/visage_ui/frame.h
@@ -185,6 +185,7 @@ namespace visage {
         setPalette(parent->palette());
     }
     Frame* parent() const { return parent_; }
+    const std::vector<Frame*>& children() const { return children_; }
 
     void setEventHandler(FrameEventHandler* handler) {
       event_handler_ = handler;


### PR DESCRIPTION
allowing post-construction traversal of the widget hierarchy from a frame reference and so forth.

Closes #11