### PR TITLE
Override the default cancelOperation method

### DIFF
--- a/visage_windowing/macos/windowing_macos.mm
+++ b/visage_windowing/macos/windowing_macos.mm
@@ -400,6 +400,8 @@ namespace visage {
 }
 - (void)moveToEndOfDocument:(id)sender {
 }
+- (void)cancelOperation:(id)sender {
+}
 
 - (visage::Point)eventPosition:(NSEvent*)event {
   NSPoint location = [event locationInWindow];


### PR DESCRIPTION
Hello!

This change fixes macOS and Bitwig Studio specific problem.
Currently, pressing escape while plugin window is active causes an instant crash.

The problem is in the `keyDown` handler.

https://github.com/VitalAudio/visage/blob/466aedf2aefab1191b66d35119791c0c928d5fee/visage_windowing/macos/windowing_macos.mm#L347-L363

As far as I can tell, `interpretKeyEvents` interprets the `Escape` key press as a `cancelOperation` event. Bitwig intercepts this event and decides that this is a signal to close the window, which calls the `~WindowMac` destructor. Then the destructor removes `visage_window`:
https://github.com/VitalAudio/visage/blob/466aedf2aefab1191b66d35119791c0c928d5fee/visage_windowing/macos/windowing_macos.mm#L857
and execution returns to the `keyDown` method.
The `keyDown` method tries to call `visage_window->handleKeyDown`, but `visage_window` pointer is invalid at that moment.
https://github.com/VitalAudio/visage/blob/466aedf2aefab1191b66d35119791c0c928d5fee/visage_windowing/macos/windowing_macos.mm#L361-L362