### PR TITLE
Bounds: Add trimming and reduction methods

### DIFF
--- a/visage_utils/space.h
+++ b/visage_utils/space.h
@@ -130,6 +130,48 @@ namespace visage {
       std::swap(width_, height_);
     }
 
+    IBounds trimTop(int amount) {
+      amount = std::min(amount, height_);
+      const IBounds trimmed(x_, y_, width_, amount);
+      y_ += amount;
+      height_ -= amount;
+      return trimmed;
+    }
+
+    IBounds trimBottom(int amount) {
+      amount = std::min(amount, height_);
+      const IBounds trimmed(x_, y_ + height_ - amount, width_, amount);
+      height_ -= amount;
+      return trimmed;
+    }
+
+    IBounds trimLeft(int amount) {
+      amount = std::min(amount, width_);
+      const IBounds trimmed(x_, y_, amount, height_);
+      x_ += amount;
+      width_ -= amount;
+      return trimmed;
+    }
+
+    IBounds trimRight(int amount) {
+      amount = std::min(amount, width_);
+      const IBounds trimmed(x_ + width_ - amount, y_, amount, height_);
+      width_ -= amount;
+      return trimmed;
+    }
+
+    IBounds reduced(int amount) const {
+      const auto newWidth = std::max(0, width_ - 2 * amount);
+      const auto newHeight = std::max(0, height_ - 2 * amount);
+      return { x_ + amount, y_ + amount, newWidth, newHeight };
+    }
+
+    IBounds reduced(int left, int right, int top, int bottom) const {
+      const auto newWidth = std::max(0, width_ - left - right);
+      const auto newHeight = std::max(0, height_ - top - bottom);
+      return { x_ + left, y_ + top, newWidth, newHeight };
+    }
+
     bool operator==(const IBounds& other) const {
       return x_ == other.x_ && y_ == other.y_ && width_ == other.width_ && height_ == other.height_;
     }
@@ -272,6 +314,48 @@ namespace visage {
     void flipDimensions() {
       std::swap(x_, y_);
       std::swap(width_, height_);
+    }
+
+    Bounds trimTop(float amount) {
+      amount = std::min(amount, height_);
+      const Bounds trimmed(x_, y_, width_, amount);
+      y_ += amount;
+      height_ -= amount;
+      return trimmed;
+    }
+
+    Bounds trimBottom(float amount) {
+      amount = std::min(amount, height_);
+      const Bounds trimmed(x_, y_ + height_ - amount, width_, amount);
+      height_ -= amount;
+      return trimmed;
+    }
+
+    Bounds trimLeft(float amount) {
+      amount = std::min(amount, width_);
+      const Bounds trimmed(x_, y_, amount, height_);
+      x_ += amount;
+      width_ -= amount;
+      return trimmed;
+    }
+
+    Bounds trimRight(float amount) {
+      amount = std::min(amount, width_);
+      const Bounds trimmed(x_ + width_ - amount, y_, amount, height_);
+      width_ -= amount;
+      return trimmed;
+    }
+
+    Bounds reduced(float amount) const {
+      const auto newWidth = std::max(0.0f, width_ - 2.0f * amount);
+      const auto newHeight = std::max(0.0f, height_ - 2.0f * amount);
+      return { x_ + amount, y_ + amount, newWidth, newHeight };
+    }
+
+    Bounds reduced(float left, float right, float top, float bottom) const {
+      const auto newWidth = std::max(0.0f, width_ - left - right);
+      const auto newHeight = std::max(0.0f, height_ - top - bottom);
+      return { x_ + left, y_ + top, newWidth, newHeight };
     }
 
     bool operator==(const Bounds& other) const {

--- a/visage_utils/tests/space_tests.cpp
+++ b/visage_utils/tests/space_tests.cpp
@@ -136,3 +136,245 @@ TEST_CASE("Breaking rectangles", "[utils]") {
   REQUIRE(!bounds1.overlaps(bounds2));
   REQUIRE(pieces.size() == 0);
 }
+
+TEST_CASE("Bounds copy", "[utils]") {
+  IBounds original(10, 20, 100, 200);
+  REQUIRE(original.copy().copy() == original);
+}
+
+TEST_CASE("IBounds trimTop", "[utils]") {
+  IBounds original(10, 20, 100, 200);
+
+  SECTION("Trim partial height") {
+    IBounds removed = original.trimTop(50);
+
+    REQUIRE(removed.x() == 10);
+    REQUIRE(removed.y() == 20);
+    REQUIRE(removed.width() == 100);
+    REQUIRE(removed.height() == 50);
+
+    REQUIRE(original.x() == 10);
+    REQUIRE(original.y() == 70);
+    REQUIRE(original.width() == 100);
+    REQUIRE(original.height() == 150);
+  }
+
+  SECTION("Trim full height") {
+    IBounds removed = original.trimTop(200);
+
+    REQUIRE(removed.x() == 10);
+    REQUIRE(removed.y() == 20);
+    REQUIRE(removed.width() == 100);
+    REQUIRE(removed.height() == 200);
+
+    REQUIRE(original.x() == 10);
+    REQUIRE(original.y() == 220);
+    REQUIRE(original.width() == 100);
+    REQUIRE(original.height() == 0);
+  }
+
+  SECTION("Trim exceeding height") {
+    IBounds removed = original.trimTop(250);
+
+    REQUIRE(removed.x() == 10);
+    REQUIRE(removed.y() == 20);
+    REQUIRE(removed.width() == 100);
+    REQUIRE(removed.height() == 200);
+
+    REQUIRE(original.x() == 10);
+    REQUIRE(original.y() == 220);
+    REQUIRE(original.width() == 100);
+    REQUIRE(original.height() == 0);
+  }
+}
+
+TEST_CASE("IBounds trimBottom", "[utils]") {
+  IBounds original(10, 20, 100, 200);
+
+  SECTION("Trim partial height") {
+    IBounds removed = original.trimBottom(50);
+
+    REQUIRE(removed.x() == 10);
+    REQUIRE(removed.y() == 170);
+    REQUIRE(removed.width() == 100);
+    REQUIRE(removed.height() == 50);
+
+    REQUIRE(original.x() == 10);
+    REQUIRE(original.y() == 20);
+    REQUIRE(original.width() == 100);
+    REQUIRE(original.height() == 150);
+  }
+
+  SECTION("Trim full height") {
+    IBounds removed = original.trimBottom(200);
+
+    REQUIRE(removed.x() == 10);
+    REQUIRE(removed.y() == 20);
+    REQUIRE(removed.width() == 100);
+    REQUIRE(removed.height() == 200);
+
+    REQUIRE(original.x() == 10);
+    REQUIRE(original.y() == 20);
+    REQUIRE(original.width() == 100);
+    REQUIRE(original.height() == 0);
+  }
+
+  SECTION("Trim exceeding height") {
+    IBounds removed = original.trimBottom(250);
+
+    REQUIRE(removed.x() == 10);
+    REQUIRE(removed.y() == 20);
+    REQUIRE(removed.width() == 100);
+    REQUIRE(removed.height() == 200);
+
+    REQUIRE(original.x() == 10);
+    REQUIRE(original.y() == 20);
+    REQUIRE(original.width() == 100);
+    REQUIRE(original.height() == 0);
+  }
+}
+
+TEST_CASE("IBounds trimLeft", "[utils]") {
+  IBounds original(10, 20, 100, 200);
+
+  SECTION("Trim partial width") {
+    IBounds removed = original.trimLeft(30);
+
+    REQUIRE(removed.x() == 10);
+    REQUIRE(removed.y() == 20);
+    REQUIRE(removed.width() == 30);
+    REQUIRE(removed.height() == 200);
+
+    REQUIRE(original.x() == 40);
+    REQUIRE(original.y() == 20);
+    REQUIRE(original.width() == 70);
+    REQUIRE(original.height() == 200);
+  }
+
+  SECTION("Trim full width") {
+    IBounds removed = original.trimLeft(100);
+
+    REQUIRE(removed.x() == 10);
+    REQUIRE(removed.y() == 20);
+    REQUIRE(removed.width() == 100);
+    REQUIRE(removed.height() == 200);
+
+    REQUIRE(original.x() == 110);
+    REQUIRE(original.y() == 20);
+    REQUIRE(original.width() == 0);
+    REQUIRE(original.height() == 200);
+  }
+
+  SECTION("Trim exceeding width") {
+    IBounds removed = original.trimLeft(150);
+
+    REQUIRE(removed.x() == 10);
+    REQUIRE(removed.y() == 20);
+    REQUIRE(removed.width() == 100);
+    REQUIRE(removed.height() == 200);
+
+    REQUIRE(original.x() == 110);
+    REQUIRE(original.y() == 20);
+    REQUIRE(original.width() == 0);
+    REQUIRE(original.height() == 200);
+  }
+}
+
+TEST_CASE("IBounds trimRight", "[utils]") {
+  IBounds original(10, 20, 100, 200);
+
+  SECTION("Trim partial width") {
+    IBounds removed = original.trimRight(30);
+
+    REQUIRE(removed.x() == 80);
+    REQUIRE(removed.y() == 20);
+    REQUIRE(removed.width() == 30);
+    REQUIRE(removed.height() == 200);
+
+    REQUIRE(original.x() == 10);
+    REQUIRE(original.y() == 20);
+    REQUIRE(original.width() == 70);
+    REQUIRE(original.height() == 200);
+  }
+
+  SECTION("Trim full width") {
+    IBounds removed = original.trimRight(100);
+
+    REQUIRE(removed.x() == 10);
+    REQUIRE(removed.y() == 20);
+    REQUIRE(removed.width() == 100);
+    REQUIRE(removed.height() == 200);
+
+    REQUIRE(original.x() == 10);
+    REQUIRE(original.y() == 20);
+    REQUIRE(original.width() == 0);
+    REQUIRE(original.height() == 200);
+  }
+
+  SECTION("Trim exceeding width") {
+    IBounds removed = original.trimRight(150);
+
+    REQUIRE(removed.x() == 10);
+    REQUIRE(removed.y() == 20);
+    REQUIRE(removed.width() == 100);
+    REQUIRE(removed.height() == 200);
+
+    REQUIRE(original.x() == 10);
+    REQUIRE(original.y() == 20);
+    REQUIRE(original.width() == 0);
+    REQUIRE(original.height() == 200);
+  }
+}
+
+TEST_CASE("IBounds reduced uniform", "[utils]") {
+  IBounds original(10, 20, 100, 200);
+
+  SECTION("Reduce by small amount") {
+    IBounds reduced = original.reduced(10);
+
+    REQUIRE(reduced.x() == 20);
+    REQUIRE(reduced.y() == 30);
+    REQUIRE(reduced.width() == 80);
+    REQUIRE(reduced.height() == 180);
+  }
+
+  SECTION("Reduce beyond IBounds") {
+    IBounds reduced = original.reduced(100);
+
+    REQUIRE(reduced.x() == 110);
+    REQUIRE(reduced.y() == 120);
+    REQUIRE(reduced.width() == 0);
+    REQUIRE(reduced.height() == 0);
+  }
+}
+
+TEST_CASE("IBounds reduced asymmetric", "[utils]") {
+  IBounds original(10, 20, 100, 200);
+
+  SECTION("Reduce with different values") {
+    IBounds reduced = original.reduced(10, 20, 30, 40);
+
+    REQUIRE(reduced.x() == 20);
+    REQUIRE(reduced.y() == 50);
+    REQUIRE(reduced.width() == 70);
+    REQUIRE(reduced.height() == 130);
+  }
+
+  SECTION("Reduce to zero") {
+    IBounds reduced = original.reduced(50, 50, 100, 100);
+
+    REQUIRE(reduced.x() == 60);
+    REQUIRE(reduced.y() == 120);
+    REQUIRE(reduced.width() == 0);
+    REQUIRE(reduced.height() == 0);
+  }
+
+  SECTION("Reduce beyond IBounds") {
+    IBounds reduced = original.reduced(60, 60, 110, 110);
+
+    REQUIRE(reduced.x() == 70);
+    REQUIRE(reduced.y() == 130);
+    REQUIRE(reduced.width() == 0);
+    REQUIRE(reduced.height() == 0);
+  }
+}


### PR DESCRIPTION
Add some utility functions to `Bounds`. I find these useful for doing static layouts.

e.g.

```
    void resized() override {
        auto b = localBounds();
        mAnalyzer.setBounds(b);
        mGradientOverlay.setBounds(b.copy().trimBottom(0.6 * height()));

        b = b.trimTop(54);
        mButton.setBounds(b.trimLeft(40).reduced(4));
        mSettings.setBounds(b.reduced(0, 3, 3, 3));
    }
```