### PR TITLE
Include <cstdint> to resolve error on build for linux

### DIFF
--- a/visage_graphics/graphics_utils.h
+++ b/visage_graphics/graphics_utils.h
@@ -27,6 +27,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace bgfx {
   struct VertexLayout;


### PR DESCRIPTION
Was throwing 

```
~/visage/visage_graphics/graphics_utils.h:63:9: error: ‘uint16_t’ does not name a type
   63 |   const uint16_t kQuadTriangles[] = {
      |         ^~~~~~~~
```

resolved by adding include