### PR TITLE
Correct popup menu on mac to ctrl modifier

### DIFF
--- a/visage_ui/events.h
+++ b/visage_ui/events.h
@@ -113,7 +113,7 @@ namespace visage {
     MouseEvent relativeTo(const Frame* new_frame) const;
 
     bool shouldTriggerPopup() const {
-      return isRightButton() || (isLeftButton() && isMainModifier());
+      return isRightButton() || (isLeftButton() && isMacCtrlDown());
     }
 
     const Frame* frame = nullptr;


### PR DESCRIPTION
I think the expected context menu modifier is the mac ctrl.
I checked for anything on windows, but couldn't find a standard modifier for context menu, I guess right mouse button suffices there.