### PR TITLE
Explicitly declare destructor as amalgmated build causes issues on Xcode/libc++

### DIFF
--- a/visage_graphics/post_effects.cpp
+++ b/visage_graphics/post_effects.cpp
@@ -100,6 +100,8 @@ namespace visage {
                                                           SampleRegion::fragmentShader()));
   }
 
+  DownsamplePostEffect::~DownsamplePostEffect() = default;
+
   DownsamplePostEffect::DownsamplePostEffect(bool hdr) : PostEffect(hdr) {
     handles_ = std::make_unique<DownsampleHandles>();
 

--- a/visage_graphics/post_effects.h
+++ b/visage_graphics/post_effects.h
@@ -48,6 +48,7 @@ namespace visage {
     static constexpr int kMaxDownsamples = 6;
 
     explicit DownsamplePostEffect(bool hdr = false);
+    ~DownsamplePostEffect() override;
 
   protected:
     void setInitialVertices(Region* region);


### PR DESCRIPTION
This PR adds the destructor explicitly in DownsampleHandles that resolves issue #62 