### PR TITLE
Set MACOSX_DEPLOYMENT_TARGET to 10.15.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,19 @@
 cmake_minimum_required(VERSION 3.17)
-project(visage VERSION 0.1.0)
-
 set(CMAKE_POLICY_DEFAULT_CMP0177 NEW)
+
+if (APPLE AND NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum macOS deployment version")
+endif ()
 
 if (NOT DEFINED CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif ()
 
+project(visage VERSION 0.1.0)
+
 if (APPLE)
   enable_language(OBJC)
   enable_language(OBJCXX)
-  if (NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
-    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum macOS deployment version")
-  endif ()
 endif ()
 
 option(VISAGE_AMALGAMATED_BUILD "Compile sources together" ON)


### PR DESCRIPTION
On my MacOS 15 (Sequoia) computer I cloned visage and did `mkdir build; cd build; cmake -GXcode .. ` Then built the ExampleBasic target. The build succeeded but the program did not run because MACOSX_DEPLOYMENT_TARGET was set to MacOS 26 (Tahoe). 

This change to CMakeLists.txt fixed the issue and got me a running binary. I don't know what the actual minimum system visage will run on is. I saw a reference to MacOS 10.15 in your GitHub Actions so that seems like a good guess. It did not build for 10.14.

Your CMakeLists.txt looks nice and clean and I hate to mess it up—unfortunately this change does need to come before the `project()` line in order to work.

MacOS 15.7.1, XCode version 26.0.1.