### PR TITLE
Fix z-order bug in addSubRegions overlap check

### DIFF
--- a/visage_graphics/layer.cpp
+++ b/visage_graphics/layer.cpp
@@ -87,7 +87,6 @@ namespace visage {
         return bounds.overlaps(other_bounds);
       });
 
-
       std::vector<IBounds> invalid_rects;
       for (const IBounds& invalid_rect : done_position.invalid_rects) {
         if (bounds.overlaps(invalid_rect))


### PR DESCRIPTION
Hiya,

Been really enjoying using visage recently, thanks for the great library!

I've been creating my own component library over visage, and noticed some issues with z-ordering that would only happen in a specific case: grandchildren of a frame A would get incorrect z-ordering when a sibling of frame A draws content.

I managed to track this down to the addSubRegions function in `visage_graphics/layer.cpp` - it was comparing local coordinates of frames with different parents, and not taking the different parent offsets into account, which was incorrectly marking some frames as overlapping. 

To be honest, I'm not entirely sure why incorrectly marking them as overlapping ends up messing with their z-order, but it does seem to be the case. Maybe something in the way overlapping regions are rendered makes assumptions about z-order? Either way, fixing this bug seems to fix that one.

The fix is just using absolute coordinates instead of local coordinates when checking for overlaps.
