### PR TITLE
Fix setCursorPosition on macOS

### DIFF
--- a/visage_windowing/macos/windowing_macos.mm
+++ b/visage_windowing/macos/windowing_macos.mm
@@ -164,10 +164,12 @@ namespace visage {
 
   void setCursorPosition(Point window_position) {
     NSWindow* window = [NSApp mainWindow];
-    if (!window) return;
+    if (!window)
+      return;
 
     NSScreen* screen = [window screen];
-    if (!screen) return;
+    if (!screen)
+      return;
 
     NSRect content_rect = [[window contentView] frame];
     NSRect screen_rect = [window convertRectToScreen:content_rect];


### PR DESCRIPTION
Heya,

It seems that setCursorPosition doesn't work properly on macOS, as confusingly CG and NS methods using different coordinate systems, with CG coords being relative to top-left, and NS coords being relative to bottom-left.

We also can't use activeWindowBounds() because that doesn't take the window's title bar into account, so the y position is still wrong there.