### PR TITLE
Reset redrawing_ flag when a child is removed from hierarchy

### DIFF
--- a/visage_ui/frame.h
+++ b/visage_ui/frame.h
@@ -337,6 +337,8 @@ namespace visage {
 
       if (event_handler_ && event_handler_->remove_from_hierarchy)
         event_handler_->remove_from_hierarchy(this);
+
+      redrawing_ = false;
     }
 
     void setMouseRelativeMode(bool visible) {


### PR DESCRIPTION
When a child gets removed from the hierarchy, if its pending a redraw, its `redrawing_` flag does not get reset, so it doesn't queue a new redraw if then re-added to a parent later as it thinks its still waiting for a previous redraw.

I've opted to reset the flag inside the component's notifyRemoveFromHierarchy, as then the component is responsible for resetting its own flag, but it would also make sense for the parent to reset the flag on the child in its eraseChild method.


lil repro:
```cpp
#include <visage/app.h>

int main() {
    visage::ApplicationWindow app;
    visage::Frame child;
    bool child_added = false;

    app.onDraw() = [&](visage::Canvas &canvas) {
        canvas.setColor(0xff333333);
        canvas.fill(0, 0, app.width(), app.height());
    };

    child.onDraw() = [&](visage::Canvas &canvas) {
        canvas.setColor(0xff4488ff);
        canvas.fill(0, 0, child.width(), child.height());
    };

    child.setBounds(50, 50, 100, 100);

    app.onMouseDown() = [&](const visage::MouseEvent& e) {
        if (!child_added) {
            app.addChild(&child);
            child_added = true;
        } else {
            child.redraw();  // Pending redraw before being removed
            app.removeChild(&child);
            child_added = false;
        }
    };
    app.setTitle("Frame Re-add Bug");
    app.show(300, 250);
    app.runEventLoop();
}

```