### PR TITLE
destroy app_ instance on guiDestroy

### DIFF
--- a/examples/ClapPlugin/clap_plugin.cpp
+++ b/examples/ClapPlugin/clap_plugin.cpp
@@ -97,10 +97,7 @@ void ClapPlugin::guiDestroy() noexcept {
 #endif
 
   app_->close();
-
-#if __linux__
   app_ = nullptr;
-#endif
 }
 
 bool ClapPlugin::guiSetParent(const clap_window* window) noexcept {


### PR DESCRIPTION
Tested with Reaper on linux, guiDestroy is invoked when closing the UI, or the parent window the plugin is displayed in. This generates a x11 bad window error: X11 Error: 3

To resolve, reset the unique_ptr app_ by assigning nullptr to it. clap/gui.h states that all resources associated with the gui should be freed.