### PR TITLE
Fix popup menu positioning when menu overflows below window

### DIFF
--- a/visage_ui/popup_menu.cpp
+++ b/visage_ui/popup_menu.cpp
@@ -268,10 +268,8 @@ namespace visage {
     int y = point.y == PopupMenu::kNotSet ? window_bounds.bottom() : window_bounds.y() + point.y;
     int bottom = y + h;
     int right = x + w;
-    if (bottom > height()) {
-      int top = point.y == PopupMenu::kNotSet ? window_bounds.y() : point.y;
-      y = std::max(0, top - h);
-    }
+    if (bottom > height())
+      y = std::max(0, static_cast<int>(window_bounds.y()) - h);
     if (right > width())
       x = std::max(0, x - w);
 


### PR DESCRIPTION
When a popup menu doesn't fit below its source frame, the fallback position uses `point.y` directly when a custom offset is set. Since `point.y` is relative to the source frame rather than the window, the menu appears at the wrong position — often near the top of the screen instead of just above the trigger element.

This uses `window_bounds.y()` consistently so the menu appears directly above the source frame regardless of whether a custom point offset was provided.

---

Discovered while working on a macOS JUCE audio plugin that uses Visage for its UI. This PR was put together with the help of Claude. Completely understand if you'd prefer to close this — just wanted to share the fix since we've been patching around it on our end whenever we update Visage.