### PR TITLE
Only call setAlwaysOnTop in showWindow when explicitly enabled

### DIFF
--- a/visage_app/application_window.cpp
+++ b/visage_app/application_window.cpp
@@ -118,7 +118,8 @@ namespace visage {
   void ApplicationWindow::showWindow(bool maximized) {
     if (!title_.empty())
       window_->setWindowTitle(title_);
-    window_->setAlwaysOnTop(always_on_top_);
+    if (always_on_top_)
+      window_->setAlwaysOnTop(true);
 
     addToWindow(window_.get());
     if (maximized)


### PR DESCRIPTION
When `always_on_top_` is `false` (the default), `showWindow()` calls `setAlwaysOnTop(false)`, which explicitly sets the window to `NSNormalWindowLevel` on macOS.

If Visage is hosted inside another application — for example, an audio plugin running inside a DAW — the host may have placed the window at a higher level (like a floating panel). The unconditional `setAlwaysOnTop(false)` demotes it to normal level, causing the Visage window to drop behind the host.

This skips the call when `always_on_top_` is `false`, leaving the window at whatever level the host assigned. `setWindowOnTop(true)` still works normally for windows that should float above everything.

---

Discovered while working on a macOS JUCE audio plugin that uses Visage for its UI. This PR was put together with the help of Claude. Completely understand if you'd prefer to close this — just wanted to share the fix since we've been patching around it on our end whenever we update Visage.