### PR TITLE
Fix keyboard handling when Visage is hosted inside a plugin on macOS

### DIFF
--- a/visage_windowing/macos/windowing_macos.mm
+++ b/visage_windowing/macos/windowing_macos.mm
@@ -383,8 +383,37 @@ namespace visage {
     [self interpretKeyEvents:[NSArray arrayWithObject:event]];
 
   visage::KeyCode key_code = visage::translateKeyCode([event keyCode]);
-  if (!self.visage_window->handleKeyDown(key_code, modifiers, [event isARepeat]))
-    [super keyDown:event];
+  if (!self.visage_window->handleKeyDown(key_code, modifiers, [event isARepeat])) {
+    if (command)
+      [[self nextResponder] keyDown:event];
+    else
+      [super keyDown:event];
+  }
+}
+
+- (BOOL)performKeyEquivalent:(NSEvent*)event {
+  if (!self.visage_window)
+    return [super performKeyEquivalent:event];
+
+  NSUInteger flags = [event modifierFlags] & NSEventModifierFlagDeviceIndependentFlagsMask;
+  bool justCmd = (flags & NSEventModifierFlagCommand) &&
+                 !(flags & NSEventModifierFlagControl) &&
+                 !(flags & NSEventModifierFlagOption);
+
+  if (justCmd && self.visage_window->hasActiveTextEntry()) {
+    NSString* chars = [event charactersIgnoringModifiers];
+    if ([chars length] == 1) {
+      unichar ch = [[chars lowercaseString] characterAtIndex:0];
+      if (ch == 'a' || ch == 'c' || ch == 'v' || ch == 'x' || ch == 'z') {
+        visage::KeyCode key_code = visage::translateKeyCode([event keyCode]);
+        int modifiers = [self keyboardModifiers:event];
+        self.visage_window->handleKeyDown(key_code, modifiers, [event isARepeat]);
+        return YES;
+      }
+    }
+  }
+
+  return [super performKeyEquivalent:event];
 }
 
 - (void)keyUp:(NSEvent*)event {


### PR DESCRIPTION
Two related issues when a Visage view is embedded inside a host application (e.g. an audio plugin running in a DAW):

**1. Text editing shortcuts don't work (Cmd+C/V/X/A/Z)**

On macOS, the host's menu system handles `performKeyEquivalent:` before `keyDown:` is called. The host's Edit menu intercepts Cmd+C, Cmd+V, etc., so they never reach Visage text editors.

This adds a `performKeyEquivalent:` override that checks `hasActiveTextEntry()`. When a text editor has focus, the shortcut is routed through `handleKeyDown` so copy/paste/select-all/undo work. When no text editor is active, the event falls through to the host so its menu shortcuts keep working normally.

**2. Unhandled command-key events are silently swallowed**

`[super keyDown:]` on macOS does not propagate events up the responder chain — it consumes them. So shortcuts like Cmd+Q never reach the application-level handler.

This forwards unhandled command-key events to `[self nextResponder]` instead of `[super keyDown:]` so they propagate up to the app. Non-command keys still go through `[super keyDown:]` as before.

---

Discovered while working on a macOS JUCE audio plugin that uses Visage for its UI. This PR was put together with the help of Claude. Completely understand if you'd prefer to close this — just wanted to share the fixes since we've been patching around them on our end whenever we update Visage.