### PR TITLE
Navigate to start/end on Up/Down in single-line text fields

### DIFF
--- a/visage_widgets/text_editor.cpp
+++ b/visage_widgets/text_editor.cpp
@@ -538,6 +538,8 @@ namespace visage {
       return focusNextTextReceiver();
     }
     if (code == KeyCode::Up) {
+      if (!text_.multiLine())
+        return moveCaretToTop(shift);
       if (modifier && shift)
         return false;
       if (modifier)
@@ -545,6 +547,8 @@ namespace visage {
       return moveCaretUp(shift);
     }
     if (code == KeyCode::Down) {
+      if (!text_.multiLine())
+        return moveCaretToEnd(shift);
       if (modifier && shift)
         return false;
       if (modifier)


### PR DESCRIPTION
In single-line text fields, Up and Down arrows attempt multi-line caret movement, which has no effect since there's only one line.

This maps Up to move-to-start and Down to move-to-end in single-line mode, matching the standard behavior of native single-line text inputs on macOS (NSTextField) and in browsers (`<input type="text">`). Shift+Up/Down extend the selection accordingly.

Multi-line text editors are unchanged.

---

Discovered while working on a macOS JUCE audio plugin that uses Visage for its UI. This PR was put together with the help of Claude. Completely understand if you'd prefer to close this — just wanted to share the fix since we've been patching around it on our end whenever we update Visage.