### PR TITLE
Cap MTKView to 60 FPS on macOS

### DIFF
--- a/visage_windowing/macos/windowing_macos.mm
+++ b/visage_windowing/macos/windowing_macos.mm
@@ -357,7 +357,7 @@ namespace visage {
   self.enableSetNeedsDisplay = NO;
   self.framebufferOnly = YES;
   self.layerContentsPlacement = NSViewLayerContentsPlacementTopLeft;
-  self.preferredFramesPerSecond = 120;
+  self.preferredFramesPerSecond = 60;
 
   [self registerForDraggedTypes:@[NSPasteboardTypeFileURL]];
   self.drag_source = [[VisageDraggingSource alloc] init];


### PR DESCRIPTION
On ProMotion displays (MacBook Pro 14"/16"), MTKView defaults to 120 FPS. For UI rendering this doubles GPU usage with no visible benefit — (at least in my current use cases) UI elements don't need to update faster than 60 Hz.

This is especially noticeable for audio plugins where GPU resources are shared with the host application and other plugins running simultaneously.

I presume there are use cases that benefit from higher frame rates, maybe this could be made configurable instead. Happy to adjust the approach.

---

Discovered while working on a macOS JUCE audio plugin that uses Visage for its UI. This PR was put together with the help of Claude. Completely understand if you'd prefer to close this — just wanted to share the fix since we've been patching around it on our end whenever we update Visage.