### PR TITLE
Log instead of assert in InstanceCounter destructor

### DIFF
--- a/visage_utils/defines.h
+++ b/visage_utils/defines.h
@@ -65,7 +65,10 @@ namespace visage {
       return instance;
     }
 
-    ~InstanceCounter() { VISAGE_ASSERT(count_ == 0); }
+    ~InstanceCounter() {
+      if (count_ != 0)
+        VISAGE_LOG("InstanceCounter: %d instance(s) of %s not released during shutdown", count_, T::vaLeakCheckerName());
+    }
 
     void add() { count_++; }
     void remove() { count_--; }


### PR DESCRIPTION
When a host application calls `exit()`, static destructors run before plugin editors have been cleaned up. The `InstanceCounter` singleton destructor sees a non-zero count and hits `VISAGE_ASSERT`, crashing the host during shutdown.

This isn't a real leak — the host just didn't give the plugin a chance to destroy its UI before tearing down the process. This replaces the assertion with `VISAGE_LOG` so it's still visible during debugging but doesn't crash the host.

We've seen this in practice with Ableton Live, which calls `exit()` on quit rather than cleanly destroying plugin editors first.

---

Discovered while working on a macOS JUCE audio plugin that uses Visage for its UI. This PR was put together with the help of Claude. Completely understand if you'd prefer to close this — just wanted to share the fix since we've been patching around it on our end whenever we update Visage.