### PR TITLE
x11: fix rendering and input on XWayland

### DIFF
--- a/visage_windowing/linux/windowing_x11.cpp
+++ b/visage_windowing/linux/windowing_x11.cpp
@@ -1460,6 +1460,8 @@ namespace visage {
     long long last_timer_microseconds = start_microseconds_;
 
     XEvent event;
+    drawCallback(0.0);
+    
     bool running = true;
     while (running) {
       FD_ZERO(&read_fds);
@@ -1482,7 +1484,7 @@ namespace visage {
         if (window == nullptr)
           continue;
 
-        if (event.type == Expose && decoration_ != Decoration::Native) {
+        if (event.type == Expose) {
           int height = clientHeight();
           window->handleResized(clientWidth(), height + 1);
           window->handleResized(clientWidth(), height);


### PR DESCRIPTION
Two fixes for XWayland where the Vulkan swapchain can be created before the compositor finishes its async surface handshake:

- Call drawCallback() before entering the event loop to trigger an initial frame immediately on startup, which ensures the framebuffer is recreated at the correct size before any user interaction.

- Remove the Decoration::Native guard from the Expose handler so that native-decorated windows (the most common standalone app case) also receive the forced framebuffer recreation on exposure.