### PR TITLE
SVG Rendering: Default gradient stop offset to 0 when attribute is omitted

### DIFF
--- a/visage_graphics/svg.cpp
+++ b/visage_graphics/svg.cpp
@@ -949,10 +949,12 @@ namespace visage {
       gradient_def.user_space = tag.data.attributes.at("gradientUnits") == "userSpaceOnUse";
 
     for (auto& child : tag.children) {
-      if (child.data.name != "stop" || !child.data.attributes.count("offset"))
+      if (child.data.name != "stop")
         continue;
 
-      float offset = parseNumber(child.data.attributes.at("offset"), 1.0f);
+      float offset = child.data.attributes.count("offset")
+                        ? parseNumber(child.data.attributes.at("offset"), 1.0f)
+                        : 0.0f;
       gradient_def.gradient.addColorStop(parseStopColor(child), offset);
     }
 


### PR DESCRIPTION
When loading SVG files created in Figma I noticed some gradients were missing. The same SVG files opened fine in JUCE and Chrome.

After some investigation I found that omitting *offset="0"* on a gradient's first *stop* was being silently dropped instead of defaulted, collapsing affected gradients to a flat colour. This omitting of the offset seems to be standard (or at least supported in all other tests).

This is a small fix sets the stop offset to 0 when the attribute isn't found.