### PR TITLE
Prevent race conditions in EventManager::addCallback

### DIFF
--- a/visage_ui/events.cpp
+++ b/visage_ui/events.cpp
@@ -73,13 +73,18 @@ namespace visage {
   }
 
   void EventManager::addCallback(std::function<void()> callback) {
+    std::lock_guard<std::mutex> lock(callback_mutex_);
     callbacks_.push_back(std::move(callback));
   }
 
   void EventManager::checkEventTimers() {
     long long current_time = time::milliseconds();
     std::vector<EventTimer*> timers = timers_;
-    std::vector<std::function<void()>> callbacks = std::move(callbacks_);
+    std::vector<std::function<void()>> callbacks;
+    {
+      std::lock_guard<std::mutex> lock(callback_mutex_);
+      callbacks = std::move(callbacks_);
+    }
 
     for (auto timer : timers)
       timer->checkTimer(current_time);

--- a/visage_ui/events.h
+++ b/visage_ui/events.h
@@ -26,6 +26,7 @@
 #include "visage_utils/space.h"
 
 #include <functional>
+#include <mutex>
 #include <string>
 
 namespace visage {
@@ -77,6 +78,7 @@ namespace visage {
 
     std::vector<EventTimer*> timers_ {};
     std::vector<std::function<void()>> callbacks_ {};
+    std::mutex callback_mutex_;
   };
 
   static void runOnEventThread(std::function<void()> function) {


### PR DESCRIPTION
First, I love Visage, thank you so much for open sourcing this project.
Second, I've never made a pull request, so bear with me :)

This PR adds a mutex to prevent race conditions in EventManager. Without this, calling visage::runOnEventThread() from a different thread can cause a race condition, which seems like it would defeat the purpose?