### PR TITLE
Fix embedded plugin window dpi scaling on macOS

### DIFF
--- a/visage_windowing/macos/windowing_macos.mm
+++ b/visage_windowing/macos/windowing_macos.mm
@@ -872,6 +872,7 @@ namespace visage {
 
   WindowMac::WindowMac(int width, int height, float scale, void* parent_handle) :
       Window(width, height) {
+    setDpiScale(scale);
     parent_view_ = (__bridge NSView*)parent_handle;
     CGRect view_frame = CGRectMake(0.0f, 0.0f, width / scale, height / scale);
 


### PR DESCRIPTION
This change fixes a rendering bug for me in my AU plugin (via clap + clap-wrapper) when it is loaded in Ableton Live on macOS. Can provide more info if needed.

Will report here if I run into any side effects.