### PR TITLE
Reset sticky BGFX clear state before drawing invalidated areas and paths atlas

### DIFF
--- a/visage_graphics/layer.cpp
+++ b/visage_graphics/layer.cpp
@@ -316,6 +316,7 @@ namespace visage {
 
     bgfx::setViewMode(submit_pass, bgfx::ViewMode::Sequential);
     bgfx::setViewRect(submit_pass, 0, 0, width_, height_);
+    bgfx::setViewClear(submit_pass, BGFX_CLEAR_NONE);
 
     if (bgfx::isValid(frame_buffer_data_->handle))
       bgfx::setViewFrameBuffer(submit_pass, frame_buffer_data_->handle);

--- a/visage_graphics/path.cpp
+++ b/visage_graphics/path.cpp
@@ -646,6 +646,7 @@ namespace visage {
 
     bgfx::setViewMode(submit_pass, bgfx::ViewMode::Sequential);
     bgfx::setViewRect(submit_pass, 0, 0, width_, height_);
+    bgfx::setViewClear(submit_pass, BGFX_CLEAR_NONE);
     bgfx::setViewFrameBuffer(submit_pass, frame_buffer_->handle);
     bgfx::setState(BGFX_STATE_WRITE_R | BGFX_STATE_BLEND_FUNC(BGFX_STATE_BLEND_ONE, BGFX_STATE_BLEND_ZERO));
     auto clear_vertices = initQuadVertices<UvVertex>(total_need_update);


### PR DESCRIPTION
This PR sets the bgfx::setViewClear to BGFX_CLEAR_NONE when invalidating layers and path atlas so that PostEffects can't contaminate the clear state (which sticks per view id).

Otherwise we can end up in a situation where post effects can alter the clear state of a submit pass (view id) that is reused later on for other drawing tasks.