### PR TITLE
Fix two macOS plugin-window bugs: nil-window max dimensions, unrecorded dpi scale

### DIFF
--- a/visage_windowing/macos/windowing_macos.mm
+++ b/visage_windowing/macos/windowing_macos.mm
@@ -872,6 +872,12 @@ namespace visage {
 
   WindowMac::WindowMac(int width, int height, float scale, void* parent_handle) :
       Window(width, height) {
+    // The standalone ctor records its scale; this one never did. Everything
+    // reading dpiScale() before the first backing-properties reset -- which
+    // includes ApplicationEditor::addToWindow pushing dpi into the frame
+    // tree -- saw 1.0, so on retina the tree laid out at half scale and the
+    // mouse landed at double coordinates in every plugin host.
+    setDpiScale(scale);
     parent_view_ = (__bridge NSView*)parent_handle;
     CGRect view_frame = CGRectMake(0.0f, 0.0f, width / scale, height / scale);
 

--- a/visage_windowing/macos/windowing_macos.mm
+++ b/visage_windowing/macos/windowing_macos.mm
@@ -1012,7 +1012,11 @@ namespace visage {
   IPoint WindowMac::maxWindowDimensions() const {
     Point borders = windowBorderSize(window_handle_);
 
-    NSScreen* screen = [window_handle_ screen];
+    // Plugin views are created before the host puts them in a window (every
+    // AUv2 host does this), so the handle - and therefore its screen - can be
+    // nil here. Messaging nil yields a 0x0 visible frame, which would clamp
+    // any size query to nothing. Fall back to the main screen.
+    NSScreen* screen = [window_handle_ screen] ?: [NSScreen mainScreen];
     NSRect visible_frame = [screen visibleFrame];
 
     int display_width = dpiScale() * (visible_frame.size.width - borders.x);


### PR DESCRIPTION
Two small fixes for visage embedded as a plugin editor on macOS, found shipping a CLAP/AUv2 instrument. Both stem from the same situation: plugin views exist before the host puts them in an NSWindow, which is the normal AUv2/VST3 flow.

**1. `WindowMac::maxWindowDimensions` messages a nil window**

Every AUv2 host instantiates the plugin view before attaching it, so `[window_handle_ screen]` is nil and the visible frame comes back 0x0. `adjustWindowDimensions` then clamps every size query to nothing — with clap-helpers' strict checking, the resulting `set_size`/`adjust_size` disagreement terminates the process. Fall back to `[NSScreen mainScreen]` when unattached.

**2. The parented `WindowMac` constructor never records its dpi scale**

The standalone constructor calls `setDpiScale(scale)`; the parented one drops it. Everything reading `dpiScale()` before the first backing-properties reset — including `ApplicationEditor::addToWindow` pushing dpi into the frame tree — sees 1.0, so on retina the tree lays out at half scale and mouse events land at double coordinates in every plugin host. The standalone path is unaffected, which hides the bug during development.

Verified in Ableton Live 12 and Logic Pro (AUv2, retina) and against the standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)